### PR TITLE
Specify NodeJS used during development

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,5 +11,8 @@
   "version": "0.1.0",
   "devDependencies": {
     "webpack-dev-server": "^3.10.3"
+  },
+  "engines": {
+    "node": "12.x"
   }
 }


### PR DESCRIPTION
This is to test using GitHub preview branches that specifying a nodeJS engine will not break deploys. (small simple check)