### PR TITLE
[Example] Add canned token auth endpoint

### DIFF
--- a/app/controllers/token_secret_controller.rb
+++ b/app/controllers/token_secret_controller.rb
@@ -1,0 +1,22 @@
+class TokenSecretController < ApplicationController
+    TOKEN = "secret"
+  
+    before_action :authenticate, except: [ :index ]
+  
+    def index
+        render plain: "Everyone can see me!"
+    end
+  
+    def edit
+        render plain: "I'm only accessible if you know the password"
+    end
+  
+    private
+        def authenticate
+            authenticate_or_request_with_http_token do |token, options|
+                # Compare the tokens in a time-constant manner, to mitigate
+                # timing attacks.
+                ActiveSupport::SecurityUtils.secure_compare(token, TOKEN)
+            end
+        end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
   root to: proc { [200, {}, ['Hello World']] }
+  resources :token_secret
 end


### PR DESCRIPTION
This is not advised or a good thing to do. GitHub online editor also let me down not asking for a branch initially.

Adds Endpoints

* `GET /token_secret`
* `GET /token_secret/:id/edit`

There is no model attached, so arbitrary id's seem to work just-fine.

JS to access hidden page (visiting in browser should show unauthenticated failed access screen)

```
let response = await fetch("/token_secret/1/edit", {
  "headers": {
    'Authorization': 'Bearer secret'
  },
  "method": "GET"
});
```